### PR TITLE
BUG: Fixed crash in STRING message receive

### DIFF
--- a/OpenIGTLinkIF/MRML/vtkMRMLIGTLConnectorNode.cxx
+++ b/OpenIGTLinkIF/MRML/vtkMRMLIGTLConnectorNode.cxx
@@ -651,6 +651,8 @@ vtkMRMLNode* vtkMRMLIGTLConnectorNode::vtkInternal::GetOrAddMRMLNodeforDevice(ig
     textNode->SetEncoding(modifiedDevice->GetContent().encoding);
     textNode->SetText(modifiedDevice->GetContent().string_msg.c_str());
     textNode->SetName(deviceName.c_str());
+    textNode->SetDescription("Received by OpenIGTLink");
+    this->External->GetScene()->AddNode(textNode);
     this->External->RegisterIncomingMRMLNode(textNode, device);
     return textNode;
   }


### PR DESCRIPTION
Newly created node was not added to the scene and therefore ID remained NULL and at some point a std::string(node->GetID()) call crashed.