### PR TITLE
Missing include for QButtonGroup

### DIFF
--- a/OpenIGTLinkRemote/Widgets/qSlicerOpenIGTLinkRemoteQueryWidget.cxx
+++ b/OpenIGTLinkRemote/Widgets/qSlicerOpenIGTLinkRemoteQueryWidget.cxx
@@ -16,6 +16,7 @@
 ==============================================================================*/
 
 // Qt includes
+#include <QButtonGroup>
 #include <QDebug>
 #include <QList>
 #include <QModelIndexList>


### PR DESCRIPTION
Necessary (at least) with Qt 5.11 on macOS 10.12.