### PR TITLE
BUG: Fix command test and remove remaining references to vtkSlicerOpenIGTLinkCommand

### DIFF
--- a/OpenIGTLinkIF/MRML/vtkMRMLIGTLConnectorNode.h
+++ b/OpenIGTLinkIF/MRML/vtkMRMLIGTLConnectorNode.h
@@ -36,7 +36,6 @@
 
 class vtkMRMLIGTLQueryNode;
 class vtkMutexLock;
-class vtkSlicerOpenIGTLinkCommand;
 
 typedef void* IGTLDevicePointer;
 
@@ -141,9 +140,13 @@ class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkMRMLIGTLConnectorNode : pub
   void UnregisterOutgoingMRMLNode(vtkMRMLNode* node);
 
 
-  // Process IO connector incoming events
+  // Process IO connector incoming device events
   // event ID is specified in OpenIGTLinkIO
   void ProcessIOConnectorEvents( vtkObject *caller, unsigned long event, void *callData );
+
+  // Process IO connector incoming command events
+  // event ID is specified in OpenIGTLinkIO
+  void ProcessIOConnectorCommandEvents(vtkObject *caller, unsigned long event, void *callData);
 
   // Description:
   // Add a new Device.

--- a/OpenIGTLinkIF/Testing/vtkMRMLConnectorCommandSendAndReceiveTest.cxx
+++ b/OpenIGTLinkIF/Testing/vtkMRMLConnectorCommandSendAndReceiveTest.cxx
@@ -110,8 +110,6 @@ int vtkMRMLConnectorCommandSendAndReceiveTest(int argc, char * argv [] )
       return EXIT_FAILURE;
       }
     }
-  
-  std::string device_name = "TestDevice";
 
   clientConnectorNode->SendCommand("Get", "<Command>\n <Parameter Name=\"Depth\" />\n </Command>", false);
   


### PR DESCRIPTION
- The test was failing due to the casting of callData to a igtlioDevice pointer in ProcessIOConnectorEvents.
- Seperated ProcessIOConnectorEvents into:
  - ProcessIOConnectorEvents
  - ProcessIOConnectorCommandEvents

- Also, invoke the DeviceModified event when a device is modified (previously was just -1), and invoke using include the modified device as CallData
