### PR TITLE
ENH: Remove unused LogConnectionErrorCheckBox and add a single log me…

### DIFF
--- a/OpenIGTLinkIF/MRML/vtkMRMLIGTLConnectorNode.cxx
+++ b/OpenIGTLinkIF/MRML/vtkMRMLIGTLConnectorNode.cxx
@@ -828,6 +828,15 @@ void vtkMRMLIGTLConnectorNode::ProcessIOConnectorEvents(vtkObject *caller, unsig
     case igtlioConnector::RemovedDeviceEvent: mrmlEvent = DeviceModifiedEvent; break;
     }
 
+  if (mrmlEvent == ConnectedEvent)
+  {
+    vtkInfoMacro("Connected: " << connector->GetServerHostname() << ":" << connector->GetServerPort());
+  }
+  else if (mrmlEvent == DisconnectedEvent)
+  {
+    vtkInfoMacro("Disconnected: " << connector->GetServerHostname() << ":" << connector->GetServerPort());
+  }
+
   igtlioDevice* modifiedDevice = static_cast<igtlioDevice*>(callData);
   if (modifiedDevice != NULL)
     {
@@ -993,13 +1002,6 @@ void vtkMRMLIGTLConnectorNode::ReadXMLAttributes(const char** atts)
       ss << attValue;
       ss >> state;
       }
-    /*if (!strcmp(attName, "logErrorIfServerConnectionFailed"))
-      {
-      std::stringstream ss;
-      ss << attValue;
-      ss >> LogErrorIfServerConnectionFailed;
-      }
-    }*/
 
   switch(type)
     {

--- a/OpenIGTLinkIF/Widgets/Resources/UI/qSlicerIGTLConnectorPropertyWidget.ui
+++ b/OpenIGTLinkIF/Widgets/Resources/UI/qSlicerIGTLConnectorPropertyWidget.ui
@@ -91,36 +91,26 @@
           </property>
          </widget>
         </item>
+       </layout>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="MRMLNodeAlgorithm">
+        <property name="text">
+         <string>MRMLNodeAlgorithm:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
         <item>
-         <widget class="QCheckBox" name="LogConnectionErrorCheckBox">
+         <widget class="QCheckBox" name="UseStreamingVolumeCheckBox">
           <property name="text">
-           <string>Log Connection Errors</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
+           <string>UseStreamingVolume</string>
           </property>
          </widget>
         </item>
        </layout>
       </item>
-      <item row="3" column="0">
-         <widget class="QLabel" name="MRMLNodeAlgorithm">
-           <property name="text">
-             <string>MRMLNodeAlgorithm:</string>
-           </property>
-         </widget>
-      </item>
-      <item row="3" column="1">
-         <layout class="QHBoxLayout" name="horizontalLayout_3">
-           <item>
-             <widget class="QCheckBox" name="UseStreamingVolumeCheckBox">
-               <property name="text">
-                 <string>UseStreamingVolume</string>
-               </property>
-             </widget>
-           </item>
-         </layout>
-      </item>  
       <item row="4" column="0">
        <widget class="QLabel" name="ConnectorHostnameLabel">
         <property name="text">

--- a/OpenIGTLinkIF/Widgets/qSlicerIGTLConnectorPropertyWidget.cxx
+++ b/OpenIGTLinkIF/Widgets/qSlicerIGTLConnectorPropertyWidget.cxx
@@ -43,8 +43,6 @@ void qSlicerIGTLConnectorPropertyWidgetPrivate::init()
                    q, SLOT(startCurrentIGTLConnector(bool)));
   QObject::connect(this->PersistentStateCheckBox, SIGNAL(toggled(bool)),
                    q, SLOT(updateIGTLConnectorNode()));
-  QObject::connect(this->LogConnectionErrorCheckBox, SIGNAL(toggled(bool)),
-                   q, SLOT(updateIGTLConnectorNode()));
   QObject::connect(this->ConnectorHostNameEdit, SIGNAL(editingFinished()),
                    q, SLOT(updateIGTLConnectorNode()));
   QObject::connect(this->ConnectorPortEdit, SIGNAL(editingFinished()),
@@ -180,7 +178,6 @@ void qSlicerIGTLConnectorPropertyWidget::onMRMLNodeModified()
     }
   d->ConnectorStateCheckBox->setChecked(!deactivated);
   d->PersistentStateCheckBox->setChecked(d->IGTLConnectorNode->GetPersistent());
-  //d->LogConnectionErrorCheckBox->setChecked(d->IGTLConnectorNode->IOConnector->GetLogErrorIfServerConnectionFailed());
 }
 
 //------------------------------------------------------------------------------
@@ -210,7 +207,6 @@ void qSlicerIGTLConnectorPropertyWidget::updateIGTLConnectorNode()
   d->IGTLConnectorNode->SetServerHostname(d->ConnectorHostNameEdit->text().toStdString());
   d->IGTLConnectorNode->SetServerPort(d->ConnectorPortEdit->text().toInt());
   d->IGTLConnectorNode->SetPersistent(d->PersistentStateCheckBox->isChecked());
-  //d->IGTLConnectorNode->SetLogErrorIfServerConnectionFailed(d->LogConnectionErrorCheckBox->isChecked());
   d->IGTLConnectorNode->SetUseStreamingVolume(d->UseStreamingVolumeCheckBox->isChecked());
   d->IGTLConnectorNode->DisableModifiedEventOff();
   d->IGTLConnectorNode->InvokePendingModifiedEvent();


### PR DESCRIPTION
…ssage when the connector node is connected or disconnected

UI now looks like this:
![image](https://user-images.githubusercontent.com/9222709/44555730-9c5f5000-a704-11e8-9b0e-d2662ea85309.png)

Connected message:
- Connected: HOSTNAME:PORT

Disconnected message:
- Disconnected: HOSTNAME:PORT

Message is currently the same for both servers and clients.

@lassoan 