### PR TITLE
BUG: Fix issues with sending vtkMRMLTextNode

### DIFF
--- a/OpenIGTLinkIF/MRML/vtkMRMLTextNode.cxx
+++ b/OpenIGTLinkIF/MRML/vtkMRMLTextNode.cxx
@@ -19,6 +19,41 @@ vtkMRMLTextNode::~vtkMRMLTextNode()
 }
 
 //----------------------------------------------------------------------------
+void vtkMRMLTextNode::SetText(const char* text)
+{
+  vtkDebugMacro(<< this->GetClassName() << " (" << this << "): setting Text to " << (text ? text : "(null)")); \
+  if (this->Text == nullptr && text == nullptr)
+    {
+      return;
+    }
+  if (this->Text && text && (!strcmp(this->Text, text)))
+    {
+    return;
+    }
+
+  delete[] this->Text;
+  if (text)
+    {
+    size_t n = strlen(text) + 1;
+    char *cp1 = new char[n];
+    const char *cp2 = (text);
+    this->Text = cp1;
+    do
+      {
+      *cp1++ = *cp2++;
+      }
+      while (--n);
+    }
+  else
+    {
+    this->Text = nullptr;
+    }
+
+  this->InvokeCustomModifiedEvent(vtkMRMLTextNode::TextModifiedEvent);
+  this->Modified();
+}
+
+//----------------------------------------------------------------------------
 void vtkMRMLTextNode::ReadXMLAttributes(const char** atts)
 {
   int disabledModify = this->StartModify();

--- a/OpenIGTLinkIF/MRML/vtkMRMLTextNode.h
+++ b/OpenIGTLinkIF/MRML/vtkMRMLTextNode.h
@@ -48,7 +48,7 @@ public:
 
   ///
   /// Set text encoding
-  vtkSetStringMacro(Text);
+  virtual void SetText(const char* text);
   vtkGetStringMacro(Text);
 
   ///


### PR DESCRIPTION
1. Check to see that the text node is not empty before attempting to store it in a string.
2. Invoke TextModifiedEvent when SetText is called so that messages are sent when text is modified.

See https://discourse.slicer.org/t/problem-using-registeroutgoingmrmlnode-in-slicer-4-10/5942