### PR TITLE
BUG: Wrap ImageMetaElement by moving to top-level

### DIFF
--- a/OpenIGTLinkIF/MRML/vtkMRMLImageMetaElement.h
+++ b/OpenIGTLinkIF/MRML/vtkMRMLImageMetaElement.h
@@ -1,0 +1,37 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Portions (c) Copyright Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+#ifndef __vtkMRMLImageMetaElement_h
+#define __vtkMRMLImageMetaElement_h
+
+// OpenIGTLinkIF MRML includes
+#include "vtkSlicerOpenIGTLinkIFModuleMRMLExport.h"
+
+class VTK_SLICER_OPENIGTLINKIF_MODULE_MRML_EXPORT vtkMRMLImageMetaElement
+{
+public:
+    std::string   Name;        /* name / description (< 64 bytes)*/
+    std::string   DeviceName;  /* device name to query the IMAGE and COLORT */
+    std::string   Modality;    /* modality name (< 32 bytes) */
+    std::string   PatientName; /* patient name (< 64 bytes) */
+    std::string   PatientID;   /* patient ID (MRN etc.) (< 64 bytes) */
+    double        TimeStamp;   /* scan time */
+    int           Size[3];     /* entire image volume size */
+    unsigned char ScalarType;  /* scalar type. see scalar_type in IMAGE message */
+};
+
+#endif

--- a/OpenIGTLinkIF/MRML/vtkMRMLImageMetaListNode.cxx
+++ b/OpenIGTLinkIF/MRML/vtkMRMLImageMetaListNode.cxx
@@ -93,13 +93,13 @@ int  vtkMRMLImageMetaListNode::GetNumberOfImageMetaElement()
 }
 
 //----------------------------------------------------------------------------
-void vtkMRMLImageMetaListNode::AddImageMetaElement(ImageMetaElement element)
+void vtkMRMLImageMetaListNode::AddImageMetaElement(vtkMRMLImageMetaElement element)
 {
   this->ImageMetaList.push_back(element);
 }
 
 //----------------------------------------------------------------------------
-void vtkMRMLImageMetaListNode::GetImageMetaElement(int index, ImageMetaElement* element)
+void vtkMRMLImageMetaListNode::GetImageMetaElement(int index, vtkMRMLImageMetaElement* element)
 {
   if (index >= 0 && index < (int) this->ImageMetaList.size())
   {

--- a/OpenIGTLinkIF/MRML/vtkMRMLImageMetaListNode.h
+++ b/OpenIGTLinkIF/MRML/vtkMRMLImageMetaListNode.h
@@ -16,6 +16,7 @@
 
 // OpenIGTLinkIF MRML includes
 #include "vtkSlicerOpenIGTLinkIFModuleMRMLExport.h"
+#include "vtkMRMLImageMetaElement.h"
 
 // MRML includes
 #include <vtkMRML.h>
@@ -45,18 +46,6 @@ public:
     NewDeviceEvent        = 118949,
   };
 
-
-  typedef struct
-  {
-    std::string   Name;        /* name / description (< 64 bytes)*/
-    std::string   DeviceName;  /* device name to query the IMAGE and COLORT */
-    std::string   Modality;    /* modality name (< 32 bytes) */
-    std::string   PatientName; /* patient name (< 64 bytes) */
-    std::string   PatientID;   /* patient ID (MRN etc.) (< 64 bytes) */
-    double        TimeStamp;   /* scan time */
-    int           Size[3];     /* entire image volume size */
-    unsigned char ScalarType;  /* scalar type. see scalar_type in IMAGE message */
-  } ImageMetaElement;
 
 public:
 
@@ -97,12 +86,12 @@ public:
 
   // Description:
   // Add image meta element
-  void AddImageMetaElement(ImageMetaElement element);
+  void AddImageMetaElement(vtkMRMLImageMetaElement element);
 
   // Description:
   // Get image meta element. If the element does not eists,
   // DeviceName is set to "".
-  void GetImageMetaElement(int index, ImageMetaElement* element);
+  void GetImageMetaElement(int index, vtkMRMLImageMetaElement* element);
 
   // Description:
   // Clear image meta element list
@@ -129,7 +118,7 @@ private:
   // Data
   //----------------------------------------------------------------
 
-  std::vector<ImageMetaElement> ImageMetaList;
+  std::vector<vtkMRMLImageMetaElement> ImageMetaList;
 
 };
 

--- a/OpenIGTLinkRemote/Widgets/qSlicerOpenIGTLinkRemoteQueryWidget.cxx
+++ b/OpenIGTLinkRemote/Widgets/qSlicerOpenIGTLinkRemoteQueryWidget.cxx
@@ -425,7 +425,7 @@ void qSlicerOpenIGTLinkRemoteQueryWidget::onMetadataQueryResponseReceived()
     d->remoteDataListTable->setRowCount(numImages);
     for (int i = 0; i < numImages; i++)
     {
-      vtkMRMLImageMetaListNode::ImageMetaElement element;
+      vtkMRMLImageMetaElement element;
 
       imgQueryNode->GetImageMetaElement(i, &element);
 


### PR DESCRIPTION
Fixes #79. Replaces the nested struct `vtkMRMLImageMetaListNode::ImageMetaElement` by a non-nested class `vtkMRMLImageMetaElement`, so that methods that use it are wrapped by vtk/Slicer.

Do let me know if there are any style inconsistencies or if I have missed something! I added the copyright from a more recent file (I think), although `vtkMRMLImageMetaListNode.h`, where the code originally was, had a different header.