### PR TITLE
WIP BUG: Specify dependencies for external projects

### DIFF
--- a/SuperBuild/External_OpenIGTLinkIO.cmake
+++ b/SuperBuild/External_OpenIGTLinkIO.cmake
@@ -1,7 +1,7 @@
 set(proj OpenIGTLinkIO)
 
 # Set dependency list
-set(${proj}_DEPENDS OpenIGTLink)
+set(${proj}_DEPENDS OpenIGTLink VTK)
 
 # Include dependent projects if any
 ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj DEPENDS_VAR ${proj}_DEPENDS)
@@ -47,7 +47,7 @@ if(NOT DEFINED OpenIGTLinkIO_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj
     GIT_TAG ${${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG}
     SOURCE_DIR "${EP_SOURCE_DIR}"
     BINARY_DIR "${EP_BINARY_DIR}"
-    CMAKE_CACHE_ARGS 
+    CMAKE_CACHE_ARGS
       ${ep_common_args}
       # Compiler settings
       -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
@@ -76,7 +76,7 @@ if(NOT DEFINED OpenIGTLinkIO_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj
     INSTALL_COMMAND ""
     DEPENDS
       ${${proj}_DEPENDS}
-    )  
+    )
   ExternalProject_GenerateProjectDescription_Step(${proj})
 
   set(OpenIGTLinkIO_DIR ${EP_BINARY_DIR})
@@ -111,7 +111,7 @@ if(NOT DEFINED OpenIGTLinkIO_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj
 
 else()
   ExternalProject_Add_Empty(${proj} DEPENDS ${${proj}_DEPENDS})
-endif()    
+endif()
 
 mark_as_superbuild(${proj}_DIR:PATH)
 ExternalProject_Message(${proj} "${proj}_DIR:${${proj}_DIR}")

--- a/SuperBuild/External_YASM.cmake
+++ b/SuperBuild/External_YASM.cmake
@@ -1,7 +1,7 @@
 set(proj YASM)
 
 # Set dependency list
-set(${proj}_DEPENDS "")
+set(${proj}_DEPENDS python)
 
 # Include dependent projects if any
 ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj DEPENDS_VAR ${proj}_DEPENDS)
@@ -26,7 +26,7 @@ if(NOT DEFINED YASM_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
       "-DCMAKE_PROJECT_yasm_INCLUDE:FILEPATH=${CMAKE_ROOT}/Modules/CTestUseLaunchers.cmake")
   endif()
 
-  find_package(PythonInterp "2.7" REQUIRED QUIET)
+  find_package(Python COMPONENTS Interpreter REQUIRED QUIET)
 
   ExternalProject_SetIfNotDefined(
     ${CMAKE_PROJECT_NAME}_${proj}_GIT_REPOSITORY
@@ -66,7 +66,7 @@ if(NOT DEFINED YASM_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
       # Install directories
       -DYASM_INSTALL_BIN_DIR:STRING=bin
       # Options
-      -DBUILD_TESTING:BOOL=OFF 
+      -DBUILD_TESTING:BOOL=OFF
       -DBUILD_EXAMPLES:BOOL=OFF
       -DBUILD_SHARED_LIBS:BOOL=OFF
       # Dependencies
@@ -89,7 +89,7 @@ if(NOT DEFINED YASM_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   # Launcher setting specific to install tree
 
   #  NA
-  
+
 else()
   ExternalProject_Add_Empty(${proj} DEPENDS ${${proj}_DEPENDENCIES})
 endif()


### PR DESCRIPTION
Fixes issues when building remote extension within a Slicer CustomApp and using MP Flags to build with multiple processes. It fails because it tries to build OpenIGTLinkIO project prior to finishing the VTK project and tries to build YASM prior to the Python project being complete.

Also includes change from
`find_package(PythonInterp "2.7" REQUIRED QUIET)` to 
`find_package(Python COMPONENTS Interpreter REQUIRED QUIET)`
because the former method, PythonInterp, has been deprecated as of CMake 3.12 (see [here](https://cmake.org/cmake/help/v3.13/module/FindPythonInterp.html)) and building Slicer requires at least CMake 3.13.