### PR TITLE
ENH: Add option to specify outgoing message header version

### DIFF
--- a/OpenIGTLinkIF/MRML/vtkMRMLIGTLConnectorNode.h
+++ b/OpenIGTLinkIF/MRML/vtkMRMLIGTLConnectorNode.h
@@ -100,7 +100,9 @@ public:
   // Description:
   // Get node XML tag name (like Volume, Model)
   virtual const char* GetNodeTagName() override
-  {return "IGTLConnector";};
+  {
+    return "IGTLConnector";
+  };
 
   // method to propagate events generated in mrml
   virtual void ProcessMRMLEvents(vtkObject* caller, unsigned long event, void* callData) override;
@@ -296,6 +298,11 @@ public:
   //ETX
 #endif // __VTK_WRAP__
 
+  // Outgoing header version
+  // Should be set before messages are sent
+  vtkGetMacro(OutgoingMessageHeaderVersionMaximum, int);
+  vtkSetMacro(OutgoingMessageHeaderVersionMaximum, int);
+
 protected:
   //----------------------------------------------------------------
   // Constructor and destroctor
@@ -305,6 +312,11 @@ protected:
   ~vtkMRMLIGTLConnectorNode();
   vtkMRMLIGTLConnectorNode(const vtkMRMLIGTLConnectorNode&);
   void operator=(const vtkMRMLIGTLConnectorNode&);
+
+  //----------------------------------------------------------------
+  // Outgoing header version
+  //----------------------------------------------------------------
+  int OutgoingMessageHeaderVersionMaximum;
 
   //----------------------------------------------------------------
   // Reference role strings


### PR DESCRIPTION
Add ComboBox to qSlicerIGTLConnectorPropertyWidget that allows the user to set the outgoing message header version.
This is done by preventing metadata from being attached to outgoing devices for header version 1.

![image](https://user-images.githubusercontent.com/9222709/69458260-ec302b00-0d3c-11ea-99ec-2f152dcbc2d0.png)
