### PR TITLE
COMP: Fix bundling of OpenIGTLinkIO external project adding VTK dependency

### DIFF
--- a/SuperBuild/External_OpenIGTLinkIO.cmake
+++ b/SuperBuild/External_OpenIGTLinkIO.cmake
@@ -2,6 +2,11 @@ set(proj OpenIGTLinkIO)
 
 # Set dependency list
 set(${proj}_DEPENDS OpenIGTLink)
+if(DEFINED Slicer_SOURCE_DIR)
+  list(APPEND ${proj}_DEPENDS
+    VTK
+    )
+endif()
 
 # Include dependent projects if any
 ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj DEPENDS_VAR ${proj}_DEPENDS)


### PR DESCRIPTION
This commit adds VTK as dependency when the OpenIGTLinkIO external project
is built in a Slicer custom application.

Co-authored-by: Sam Horvath <sam.horvath@kitware.com>