### PR TITLE
Bug: Query node device name fix.

### DIFF
--- a/OpenIGTLinkRemote/Widgets/qSlicerOpenIGTLinkRemoteQueryWidget.cxx
+++ b/OpenIGTLinkRemote/Widgets/qSlicerOpenIGTLinkRemoteQueryWidget.cxx
@@ -280,7 +280,10 @@ void qSlicerOpenIGTLinkRemoteQueryWidget::queryRemoteList()
     qCritical() << Q_FUNC_INFO << " failed: invalid connector node";
     return;
   }
-
+  // when no device name given, connectnode will not process the response message.
+  // in openigtlink IF prior to Slicer 4.8, an node with name "OpenIGTLink" is created when no device name given.
+  // We can set the IGTLDeviceName to be "OpenIGTLink" as to be consistent with older OpenIGTLINK IF moduel. There is another limitation in set igtlDeviceName, the name should not longer than the DeviceName Length defined in Openigtlink header, otherwize the name would be trunctated and resulting miss match in GetPendingQueryNodeForDevice() call in connect node.
+  d->metadataQueryNode->SetIGTLDeviceName("OpenIGTLink");
   if (d->typeButtonGroup.checkedId() == qSlicerOpenIGTLinkRemoteQueryWidgetPrivate::TYPE_IMAGE)
   {
     d->metadataQueryNode->SetIGTLName("IMGMETA");


### PR DESCRIPTION
when no device name given, connectnode will not process the incoming response message. In openigtlinkIF prior to Slicer 4.8, a node with name "OpenIGTLink" is created when no device name given. We can set the IGTLDeviceName to be "OpenIGTLink" as to be consistent with older OpenIGTLINK IF moduel. There is another limitation in set igtlDeviceName, the name should not longer than the DeviceName Length defined in Openigtlink header, otherwise the name would be truncated and resulting miss match in GetPendingQueryNodeForDevice() call in connect node.