### PR TITLE
ENH: Copy metadata from OpenIGTLink messages to MRML nodes

### DIFF
--- a/OpenIGTLinkIF/MRML/vtkMRMLIGTLConnectorNode.cxx
+++ b/OpenIGTLinkIF/MRML/vtkMRMLIGTLConnectorNode.cxx
@@ -599,6 +599,13 @@ void vtkMRMLIGTLConnectorNode::ProcessIncomingDeviceModifiedEvent(
         }
       }
     }
+
+    // copy metadata from igtl message to MRML node
+    for (igtl::MessageBase::MetaDataMap::const_iterator iter = modifiedDevice->GetMetaData().begin(); iter != modifiedDevice->GetMetaData().end(); ++iter)
+    {
+      std::string tag = "OpenIGTLink." + iter->first;
+      modifiedNode->SetAttribute(tag.c_str(), iter->second.second.c_str());
+    }
   }
 
   vtkMRMLIGTLQueryNode* queryNode = this->Internal->GetPendingQueryNodeForDevice(modifiedDevice);


### PR DESCRIPTION
The intended use case for this change is to enable Slicer access
to PLUS metadata added as custom fields on an image or transform.