### PR TITLE
COMP: Fix missing transition from vtkMutexLock to std:mutex

### DIFF
--- a/OpenIGTLinkIF/MRML/vtkIGTLCircularBuffer.h
+++ b/OpenIGTLinkIF/MRML/vtkIGTLCircularBuffer.h
@@ -26,10 +26,9 @@
 
 // STD includes
 #include <string>
+#include <mutex>
 
 #define IGTLCB_CIRC_BUFFER_SIZE    3
-
-class vtkMutexLock;
 
 class vtkIGTLCircularBuffer : public vtkObject
 {
@@ -57,8 +56,7 @@ protected:
   virtual ~vtkIGTLCircularBuffer();
 
 protected:
-
-  vtkMutexLock*      Mutex;
+  std::mutex         Mutex;
   int                Last;        // updated by connector thread
   int                InPush;      // updated by connector thread
   int                InUse;       // updated by main thread


### PR DESCRIPTION
Replace vtkMutexLock with std::mutex.

This is a followup to https://github.com/openigtlink/SlicerOpenIGTLink/commit/0df19d0cb97a3aeb5ec9bea5d7848b99f1a6f23c.

cc: @Sunderlandkyl Is it correct that this set of changes should have been included originally in the above linked commit? Upon typing this up I realized these don't quite match up with the changes made in https://github.com/IGSIO/OpenIGTLinkIO/commit/207f5cd7c7234d83cf53e674de8753243221d825 for igtlioCircularBuffer.cxx. What's the difference between igtlioCircularBuffer and vtkIGTLCircularBuffer?