### PR TITLE
COMP: Update minimum required CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20.6...3.22.6 FATAL_ERROR)
 
 project(SlicerOpenIGTLink)
 

--- a/OpenIGTLinkIF/CMakeLists.txt
+++ b/OpenIGTLinkIF/CMakeLists.txt
@@ -1,8 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
-
-if(POLICY CMP0048)
-  cmake_policy(SET CMP0048 NEW) # CMake 3.0.0
-endif()
+cmake_minimum_required(VERSION 3.20.6...3.22.6 FATAL_ERROR)
 
 set(MODULE_NAME "OpenIGTLinkIF")
 set(MODULE_TITLE "OpenIGTLinkIF")


### PR DESCRIPTION
This is in line with the CMake policy of latest Slicer stable 5.10.0. See https://github.com/Slicer/Slicer/blob/a2b6d082be04274a849884fbb1e85634a9df90fb/CMakeLists.txt#L1

Same type change as in https://github.com/SlicerRt/SlicerRT/pull/290. cc: @sjh26 @jcfr 

This aims to resolve https://github.com/openigtlink/SlicerOpenIGTLink/issues/144.